### PR TITLE
implement Semigroup for types that already implement Monoid

### DIFF
--- a/hwsl2.cabal
+++ b/hwsl2.cabal
@@ -92,6 +92,8 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.8 && <5, bytestring >=0.10
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups == 0.18.*
 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -124,6 +126,8 @@ test-suite test
                        tasty >=0.10,
                        tasty-quickcheck >=0.8,
                        quickcheck-properties >= 0.1
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups == 0.18.*
   include-dirs:        src/core
   if flag(avx2)
     cc-options:        -Wall -mavx2 -msse4.1 -msse2 -mpclmul
@@ -147,6 +151,8 @@ benchmark bench
                        criterion >=1.0,
                        cryptohash >=0.11,
                        parallel >=3.2
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups == 0.18.*
   include-dirs:        src/core
   if flag(avx2)
     cc-options:        -Wall -mavx2 -msse4.1 -msse2 -mpclmul

--- a/src/Data/Hash/SL2.hs
+++ b/src/Data/Hash/SL2.hs
@@ -45,6 +45,8 @@ module Data.Hash.SL2
 
 import Prelude hiding (concat)
 
+import Data.Semigroup (Semigroup, (<>))
+
 import Data.Hash.SL2.Internal (Hash)
 import Data.Hash.SL2.Unsafe
 import qualified Data.Hash.SL2.Mutable as Mutable
@@ -65,9 +67,12 @@ instance Eq Hash where
 instance Ord Hash where
   compare a b = unsafePerformIO $ unsafeUseAsPtr2 a b Mutable.cmp
 
+instance Semigroup Hash where
+  (<>) = concat
+
 instance Monoid Hash where
   mempty = unit
-  mappend = concat
+  mappend = (<>)
   mconcat = concatAll
 
 -- | /O(n)/ Calculate the hash of the 'ByteString'. Alias for @('append' 'unit')@.

--- a/src/Data/Hash/SL2/Chunk.hs
+++ b/src/Data/Hash/SL2/Chunk.hs
@@ -3,6 +3,7 @@ module Data.Hash.SL2.Chunk where
 import Data.ByteString
 import Data.Hash.SL2
 import Data.Monoid
+import Data.Semigroup (Semigroup, (<>))
 
 data Chunk = Chunk
   { getChunkHash :: Hash
@@ -15,9 +16,12 @@ instance Eq Chunk where
 instance Ord Chunk where
   compare a b = compare (getChunkHash a) (getChunkHash b)
 
+instance Semigroup Chunk where
+   a <> b = Chunk (getChunkHash a <> getChunkHash b) (getChunkBytes a <> getChunkBytes b)
+
 instance Monoid Chunk where
   mempty = Chunk mempty mempty
-  mappend a b = Chunk (getChunkHash a <> getChunkHash b) (getChunkBytes a <> getChunkBytes b)
+  mappend = (<>)
   mconcat as = Chunk (mconcat $ fmap getChunkHash as) (mconcat $ fmap getChunkBytes as)
 
 fromByteString :: ByteString -> Chunk


### PR DESCRIPTION
Addresses #4 per recommendation under https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode (avoiding `CPP`)