### PR TITLE
ensure compatibility with newer GHC versions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,8 @@
 *.x86_64
 *.hex
 
+# stack
 .stack-work
+
+# cabal
+dist*

--- a/src/Data/Hash/SL2.hs
+++ b/src/Data/Hash/SL2.hs
@@ -65,25 +65,30 @@ instance Eq Hash where
 instance Ord Hash where
   compare a b = unsafePerformIO $ unsafeUseAsPtr2 a b Mutable.cmp
 
+instance Semigroup Hash where 
+  (<>) = concat
+
 instance Monoid Hash where
   mempty = unit
-  mappend = concat
   mconcat = concatAll
 
 -- | /O(n)/ Calculate the hash of the 'ByteString'. Alias for @('append' 'unit')@.
 hash :: ByteString -> Hash
 hash = append unit
+{-# inline[1] hash #-}
 
 -- | /O(n)/ Append the hash of the 'ByteString' to the existing 'Hash'.
 -- A significantly faster equivalent of @((. 'hash') . 'concat')@.
 append :: Hash -> ByteString -> Hash
 append h s = fst $ unsafePerformIO $ Mutable.withCopy h $ Mutable.append s
+{-# inline[1] append #-}
 {-# RULES "hash/concat" forall h s . concat h (hash s) = append h s #-}
 
 -- | /O(n)/ Prepend the hash of the 'ByteString' to the existing 'Hash'.
 -- A significantly faster equivalent of @('concat' . 'hash')@.
 prepend :: ByteString -> Hash -> Hash
 prepend s h = fst $ unsafePerformIO $ Mutable.withCopy h $ Mutable.prepend s
+{-# inline[1] prepend #-}
 {-# RULES "concat/hash" forall s h . concat (hash s) h = prepend s h #-}
 
 -- | /O(n)/ Append the hash of every 'ByteString' to the existing 'Hash', from left to right.

--- a/src/Data/Hash/SL2/Chunk.hs
+++ b/src/Data/Hash/SL2/Chunk.hs
@@ -1,12 +1,11 @@
-module Data.Hash.SL2.Chunk where
+module Data.Hash.SL2.Chunk (Chunk(..), fromByteString) where
 
 import Data.ByteString
 import Data.Hash.SL2
-import Data.Monoid
 
 data Chunk = Chunk
-  { getChunkHash :: Hash
-  , getChunkBytes :: ByteString
+  { getChunkHash :: {-# unpack #-} !Hash
+  , getChunkBytes :: {-# unpack #-} !ByteString
   }
 
 instance Eq Chunk where
@@ -15,9 +14,11 @@ instance Eq Chunk where
 instance Ord Chunk where
   compare a b = compare (getChunkHash a) (getChunkHash b)
 
+instance Semigroup Chunk where
+  a <> b = Chunk (getChunkHash a <> getChunkHash b) (getChunkBytes a <> getChunkBytes b)
+
 instance Monoid Chunk where
   mempty = Chunk mempty mempty
-  mappend a b = Chunk (getChunkHash a <> getChunkHash b) (getChunkBytes a <> getChunkBytes b)
   mconcat as = Chunk (mconcat $ fmap getChunkHash as) (mconcat $ fmap getChunkBytes as)
 
 fromByteString :: ByteString -> Chunk

--- a/src/Data/Hash/SL2/Internal.hs
+++ b/src/Data/Hash/SL2/Internal.hs
@@ -12,29 +12,29 @@ newtype Hash = H (ForeignPtr ())
 hashSize = 64 :: Int
 hashLen = 86 :: Int
 
-foreign import capi "sl2-inl.h sl2_valid"
+foreign import capi unsafe "sl2-inl.h sl2_valid"
   valid :: Ptr Hash -> IO CInt
 
-foreign import capi "sl2-inl.h sl2_eq"
+foreign import capi unsafe "sl2-inl.h sl2_eq"
   eq :: Ptr Hash -> Ptr Hash -> IO CInt
 
-foreign import capi "sl2-inl.h sl2_cmp"
+foreign import capi unsafe "sl2-inl.h sl2_cmp"
   cmp :: Ptr Hash -> Ptr Hash -> IO CInt
 
-foreign import capi "sl2-inl.h sl2_unit"
+foreign import capi unsafe "sl2-inl.h sl2_unit"
   unit :: Ptr Hash -> IO ()
 
-foreign import capi "sl2-inl.h sl2_mul_buf_right"
+foreign import capi unsafe "sl2-inl.h sl2_mul_buf_right"
   append :: Ptr Hash -> Ptr CChar -> CSize -> IO ()
 
-foreign import capi "sl2-inl.h sl2_mul_buf_left"
+foreign import capi unsafe "sl2-inl.h sl2_mul_buf_left"
   prepend :: Ptr Hash -> Ptr CChar -> CSize -> IO ()
 
-foreign import capi "sl2-inl.h sl2_mul"
+foreign import capi unsafe "sl2-inl.h sl2_mul"
   concat :: Ptr Hash -> Ptr Hash -> Ptr Hash -> IO ()
 
-foreign import capi "sl2-inl.h sl2_serialize"
+foreign import capi unsafe "sl2-inl.h sl2_serialize"
   serialize :: Ptr Hash -> Ptr CChar -> IO ()
 
-foreign import capi "sl2-inl.h sl2_unserialize"
+foreign import capi unsafe "sl2-inl.h sl2_unserialize"
   unserialize :: Ptr Hash -> Ptr CChar -> IO ()

--- a/src/Data/Hash/SL2/Test.hs
+++ b/src/Data/Hash/SL2/Test.hs
@@ -24,6 +24,7 @@ instance Arbitrary B.ByteString where
 instance Arbitrary Hash where
   arbitrary = fmap hash arbitrary
 
+main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
@@ -41,7 +42,7 @@ tests = testGroup "Properties"
   , testGroup "compare"
 
     [ testProperty "eq" $
-        \a -> compare (hash a) (hash a) == EQ
+        \a -> hash a == hash a
 
     , testProperty "gt" $
         \a b c -> (a > b && b > c) ==> (a :: Hash) > c
@@ -95,13 +96,13 @@ tests = testGroup "Properties"
 
   , testGroup "append"
 
-    [ testGroup "single string" $
+    [ testGroup "single string"
 
       [ testProperty "equal to ((. hash) . concat)" $
           \a b -> ((. hash) . concat) a b == a `append` b
       ]
 
-    , testGroup "multiple strings" $
+    , testGroup "multiple strings"
 
       [ testProperty "equal to (foldl append)" $
           \a (b :: [B.ByteString]) -> foldl append a b == a `foldAppend` b
@@ -111,13 +112,13 @@ tests = testGroup "Properties"
 
   , testGroup "prepend"
 
-    [ testGroup "single string" $
+    [ testGroup "single string"
 
       [ testProperty "equal to (concat . hash)" $
           \a b -> (concat . hash) a b == a `prepend` b
       ]
 
-    , testGroup "multiple strings" $
+    , testGroup "multiple strings"
 
       [ testProperty "equal to (flip (foldr prepend)" $
           \(a :: [B.ByteString]) b -> foldr prepend b a == a `foldPrepend` b


### PR DESCRIPTION
This ensures compatibility with newer GHC versions which added `Semigroup` as a superclass to `Monoid`. 